### PR TITLE
markup changes to reflect recent prototype changes

### DIFF
--- a/plonesocial/activitystream/adapters.py
+++ b/plonesocial/activitystream/adapters.py
@@ -53,7 +53,7 @@ class ContentActivity(AbstractContentActivity):
     def __init__(self, context):
         super(ContentActivity, self).__init__(context)
         self.userid = context.getOwnerTuple()[1]
-        self.render_type = 'content'
+        self.render_type = 'item'
         self.text = context.Description() + self._tags(context.Subject())
 
     def _tags(self, source):

--- a/plonesocial/activitystream/browser/templates/stream.pt
+++ b/plonesocial/activitystream/browser/templates/stream.pt
@@ -17,8 +17,7 @@
         <tal:block replace="structure view/status_provider" />
 
         <div id="activity-stream"
-             class="activity-stream pat-packery packery-ready"
-             data-pat-packery="column-width: 500; gutter-width: 30px; item-selector: .post;">
+             class="activity-stream">
 
           <h2 tal:condition="view/tag" i18n:translate="">Updates tagged
           #<span tal:replace="view/tag" i18n:name="tag">sometag</span>

--- a/plonesocial/activitystream/browser/templates/stream_tile.pt
+++ b/plonesocial/activitystream/browser/templates/stream_tile.pt
@@ -1,8 +1,7 @@
 <html>
     <body>
         <div id="activity-stream"
-             class="activity-stream pat-packery packery-ready"
-             data-pat-packery="column-width: 500; gutter-width: 30px; item-selector: .post;">
+             class="activity-stream">
 
           <h2 tal:condition="view/tag" i18n:translate="">Updates tagged
           #<span tal:replace="view/tag" i18n:name="tag">sometag</span>


### PR DESCRIPTION
Hi @gyst, I noticed a formatting difference in the activity stream compared to proto and changed the affected classes. Main difference is that the posts now have a proper margin-bottom of 30 px again and don't "stick" together anymore. Could you review and potentially merge?