### PR TITLE
Fix the filter for already handled activities.

### DIFF
--- a/plonesocial/activitystream/browser/stream_provider.py
+++ b/plonesocial/activitystream/browser/stream_provider.py
@@ -153,11 +153,13 @@ class StreamProvider(object):
         # parent post we already rendered.
         seen_thread_ids = []
         for activity in activities:
-            if activity.id in seen_thread_ids:
+            if activity.thread_id and activity.thread_id in seen_thread_ids:
                 continue
 
             if IStatusActivityReply.providedBy(activity):
                 seen_thread_ids.append(activity.thread_id)
+            else:
+                seen_thread_ids.append(activity.id)
 
             yield activity
 


### PR DESCRIPTION
 We need to check for seen activities based on the thread_id, not the activity's id