### PR TITLE
Continue #34, fix duplicated posts in the activity stream

### DIFF
--- a/plonesocial/activitystream/browser/stream_provider.py
+++ b/plonesocial/activitystream/browser/stream_provider.py
@@ -153,7 +153,8 @@ class StreamProvider(object):
         # parent post we already rendered.
         seen_thread_ids = []
         for activity in activities:
-            if activity.thread_id and activity.thread_id in seen_thread_ids:
+            if (activity.thread_id and activity.thread_id in seen_thread_ids) \
+                    or activity.id in seen_thread_ids:
                 continue
 
             if IStatusActivityReply.providedBy(activity):


### PR DESCRIPTION
We ALSO need to check, in case we handle get a StatusUpdate (i.e. not a reply), if its id is part of the list of seen activities.

The original code had already contained this check. In #34 I had replaced it with only comparing for the thread id. But we need to check for both cases.