### PR TITLE
Update activity terminology in line with prototype

### DIFF
--- a/plonesocial/activitystream/browser/prototype/post.html
+++ b/plonesocial/activitystream/browser/prototype/post.html
@@ -32,7 +32,7 @@
       </h4>
     </a>
     <p class="byline">
-      <em class="action" i18n:translate="label_says">says:</em>
+      <em class="action" i18n:translate="label_posted">posted</em>
       <time tal:content="activity_provider/date">
         8/23/2001 12:40:44 PM
       </time> |


### PR DESCRIPTION
* The old plonesocial terminology 'says:' makes no sense in the ploneintranet.theme
  layout. Changed to reflect the prototype text.