### PR TITLE
Reinstated attachment preview support in feed

### DIFF
--- a/plonesocial/activitystream/browser/prototype/comment.html
+++ b/plonesocial/activitystream/browser/prototype/comment.html
@@ -32,10 +32,10 @@
                 </p>
             </section>
 
-            <section class="preview" tal:condition="nothing">
+            <section class="preview">
                 <figure tal:repeat="attachment provider/attachments">
                     <a href="/incredibly-boring-document" tal:attributes="href attachment">
-                        <img alt="" src="/media/preview_thumb_1.jpg" alt="" tal:attributes="src string:${attachment}/thumb" />
+                        <img alt="" src="/media/preview_thumb_1.jpg" alt="" tal:attributes="src string:${attachment}" />
                     </a>
                 </figure>
             </section>

--- a/plonesocial/activitystream/browser/prototype/post.html
+++ b/plonesocial/activitystream/browser/prototype/post.html
@@ -74,7 +74,8 @@
 
     <figure tal:repeat="attachment activity_provider/attachments">
       <a href="/incredibly-boring-document" tal:attributes="href attachment">
-        <img src="/media/preview_thumb_1.jpg" alt="" tal:attributes="src string:${attachment}/thumb">
+        <img src="/media/preview_thumb_1.jpg" alt=""
+             tal:attributes="src string:${attachment}">
       </a>
     </figure>
 


### PR DESCRIPTION
* Did some refactoring so that attachment lookup is now defined by the
  relevant activity provider